### PR TITLE
Added new option to exclude association

### DIFF
--- a/doc/general_info.md
+++ b/doc/general_info.md
@@ -25,6 +25,7 @@ argument) will include the following standard options:
 * `:model_class` - If configured, the ActiveRecord model class associated with the API endpoint
 * `:user` - The currently-logged-in user
 * `:user_id` - ID of the currently-logged-in user
+* `:exclude_associations` - Array of association names which are to be excluded from API response
 
 *Note API-specific additional options may be universally included by overriding the
 `prepare_options()` method in the API controller.*
@@ -41,3 +42,16 @@ Below is a summary of API operation categories used when controlling when and ho
 * `:other` - Operation that does not fit into one of the aformeneted CRUD operation categories
 * `:filter` - Used when attribute is being evaluated for filtering purposes
 * `:sort` - Used when attribute is being evaluated for sorted purposes
+
+### Index API options
+Index API - View list of resources.
+
+* `exclude_associations[]` - excludes the association metadata from response.
+
+
+### Show API options
+Show API - View individual resource.
+
+* `exclude_associations[]` - excludes the association metadata from response.
+
+*Note exclude_associations option is of type array.*

--- a/lib/model-api/base_controller.rb
+++ b/lib/model-api/base_controller.rb
@@ -188,6 +188,9 @@ module ModelApi
           default_link_options = request.params.to_h.symbolize_keys
           opts[:collection_link_options] ||= default_link_options
           opts[:object_link_options] ||= default_link_options
+          if default_link_options[:exclude_associations].present?
+            opts[:exclude_associations] ||= default_link_options[:exclude_associations]
+          end
         end
         opts[:options_initialized] ||= true
         opts

--- a/lib/model-api/utils.rb
+++ b/lib/model-api/utils.rb
@@ -424,7 +424,7 @@ module ModelApi
         collection
       end
 
-      # Does not eager load associations mentioned in the exclude_assocations
+      # Does not eager load associations mentioned in the exclude_associations
       # array defined by user.
       def remove_excluded_associations(includes, opts)
         includes_dup = includes.compact.uniq.deep_dup
@@ -449,7 +449,7 @@ module ModelApi
       end
 
       # Incase of nested associations (in collection_inlcudes) delete the key with the association name
-      # and then loop over to delete associations present as element of a array if any
+      # and then loop over the collection to delete associations present as element of the array if any
       def remove_association_from_hash(hash_collection, association)
         if hash_collection.keys.include?(association)
           hash_collection.delete(association)

--- a/lib/model-api/utils.rb
+++ b/lib/model-api/utils.rb
@@ -459,6 +459,13 @@ module ModelApi
         metadata
       end
 
+      def exculde_associations_metadata(metadata, obj, opts = {})
+        exclude_associations = opts[:exclude_associations].try(:map, &:to_sym)
+        if exclude_associations.present?
+          return (exclude_associations.include?(obj.table_name) || exclude_associations.include?(metadata[:key]))
+        end
+      end
+
       def include_item?(metadata, obj, operation, opts = {})
         return false unless metadata.is_a?(Hash)
         return false unless include_item_meets_admin_criteria?(metadata, obj, operation, opts)
@@ -467,6 +474,7 @@ module ModelApi
         return eval_bool(obj, metadata[:sort], opts) if operation == :sort
         return false unless include_item_meets_read_write_criteria?(metadata, obj, operation, opts)
         return false unless include_item_meets_incl_excl_criteria?(metadata, obj, operation, opts)
+        return false if exculde_associations_metadata(metadata, obj, opts)
         true
       end
 

--- a/lib/model-api/utils.rb
+++ b/lib/model-api/utils.rb
@@ -419,8 +419,47 @@ module ModelApi
           includes << attr_metadata[:key] if attr_metadata[:type] == :association
         end
         includes = includes.compact.uniq
+        includes = remove_excluded_associations(includes, opts)
         collection = collection.includes(includes) if includes.present?
         collection
+      end
+
+      # New Method: Does not eager load associations mentioned in the exclude_assocations
+      # array defined by user.
+      def remove_excluded_associations(includes, opts)
+        includes_dup = includes.compact.uniq.deep_dup
+        exclude_associations = opts[:exclude_associations]
+        return includes_dup unless exclude_associations.present?
+        exclude_associations.each do |association|
+          process_collection_array(includes_dup, association.to_sym)
+        end
+        includes_dup
+      end
+
+      # If the association is present in array form (in collection_includes) delete it.
+      # Then loop over the array elements to remove the association incase of nested associations.
+      def process_collection_array(array_collection, association)
+        array_collection.delete(association)
+        array_collection.each_with_index do |collection, i|
+          if collection.is_a?(Hash)
+            array_collection[i] = process_collection_hash(collection, association)
+          end
+        end
+        array_collection
+      end
+
+      # Incase of nested associations (in collection_inlcudes) delete the key with the association name
+      # and then loop over to delete associations present as element of a array if any
+      def process_collection_hash(hash_collection, association)
+        if hash_collection.keys.include?(association)
+          hash_collection.delete(association)
+        else
+          hash_collection.each do |key, value|
+            hash_collection[key] =
+              process_collection_array(value, association) if value.is_a?(Array)
+          end
+        end
+        hash_collection
       end
 
       def find_class(obj, opts = {})
@@ -462,7 +501,7 @@ module ModelApi
       def exculde_associations_metadata(metadata, obj, opts = {})
         exclude_associations = opts[:exclude_associations].try(:map, &:to_sym)
         if exclude_associations.present?
-          return (exclude_associations.include?(obj.table_name) || exclude_associations.include?(metadata[:key]))
+          (exclude_associations.include?(obj.table_name) || exclude_associations.include?(metadata[:key]))
         end
       end
 

--- a/model-api.gemspec
+++ b/model-api.gemspec
@@ -3,7 +3,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = 'model-api'
-  s.version = '0.8.10'
+  s.version = '0.8.11'
   s.summary = 'Create easy REST API\'s using metadata inside your ActiveRecord models'
   s.description = 'Ruby gem allowing Ruby on Rails developers to create REST API’s using ' \
       'metadata defined inside their ActiveRecord models.'


### PR DESCRIPTION
## Problem: 
All the association metadata was returned for an API call.

## Solution: 
Added a option in gem `exclude_associations` to exclude the association data from API response. 

## Changes: 
1. Added new option `exclude_associations` to the gem.
2. Updated the method to which includes the metadata.
3. Updated the gem version
4. Updated the documentation for the new options
5. Removed eager loading of the association if association are excluded