### PR TITLE
Allow controller defined attributes with value as :false

### DIFF
--- a/lib/model-api/renderer.rb
+++ b/lib/model-api/renderer.rb
@@ -34,7 +34,7 @@ module ModelApi
         render_values = []
         render_assoc = []
         metadata.each do |attr, attr_metadata|
-          if (value = attr_metadata[:value]).present?
+          if !(value = attr_metadata[:value]).nil?
             render_values << [attr, value, attr_metadata]
           elsif obj.respond_to?(attr.to_s)
             render_values << [attr, obj.send(attr.to_sym), attr_metadata]

--- a/model-api.gemspec
+++ b/model-api.gemspec
@@ -3,7 +3,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = 'model-api'
-  s.version = '0.8.11'
+  s.version = '0.8.12'
   s.summary = 'Create easy REST API\'s using metadata inside your ActiveRecord models'
   s.description = 'Ruby gem allowing Ruby on Rails developers to create REST API’s using ' \
       'metadata defined inside their ActiveRecord models.'


### PR DESCRIPTION
## Issue
It was observed that when additional attributes were added to an object at controller level and the values of these attribute was `false` or `' '`, it resulted in an error. 

## Reason for Issue
The `attrs_by_type(obj, metadata)` method was checking if the value is `present?`. When the value is `false`, `false.present?` will return false and the if condition does not pass.

## Correction
Corrected the `attrs_by_type(obj, metadata)` to check that the the value is not `nil?` instead.